### PR TITLE
Scaling for images and videos

### DIFF
--- a/animated_gif.pde
+++ b/animated_gif.pde
@@ -2,6 +2,7 @@ class AnimatedGif {
   int x, y;
   int targetX, targetY;
   float easing = 0.1;
+  int currentScale = 100;
 
   Gif picture;
   Image[] frames; 
@@ -101,6 +102,10 @@ class AnimatedGif {
     return picture;
   }
 
+  void setScale(int s) {
+    currentScale = s;
+  }
+
   void draw() {
     int dx = targetX - x;
     if(abs(dx) > 1) {
@@ -116,6 +121,6 @@ class AnimatedGif {
       frames[i].applyEffects();
     }
 
-    image(picture, x, y);
+    image(picture, x, y, picture.width*(currentScale/100), picture.height*(currentScale/100));
   }
 };

--- a/channel.pde
+++ b/channel.pde
@@ -243,6 +243,10 @@ class Channel implements Runnable {
     if (instr.hasKey("width") && instr.hasKey("height")) {
       img.updateSize(instr.getInt("width"), instr.getInt("height"));
     }
+
+    if (instr.hasKey("scale")) {
+      img.setScale(instr.getInt("scale"));
+    }
     
     if (instr.hasKey("brightness")) {
       img.startBrightness(instr.getInt("brightness"), instr.getInt("totaltime"), instr.getInt("numupdates"));
@@ -306,6 +310,10 @@ class Channel implements Runnable {
       gif = gifs.get(id);
     }
 
+    if (instr.hasKey("scale")) {
+      gif.setScale(instr.getInt("scale"));
+    }
+
     if (instr.hasKey("transparency")) {
       gif.startTransparency(instr.getInt("transparency"), instr.getInt("totaltime"), instr.getInt("numupdates"));
     }
@@ -366,6 +374,10 @@ class Channel implements Runnable {
       vid = backVideo;
     } else {
       vid = videos.get(id);
+    }
+
+    if (instr.hasKey("scale")) {
+      vid.setScale(instr.getInt("scale"));
     }
 
     if (instr.hasKey("easing")) {

--- a/image.pde
+++ b/image.pde
@@ -2,6 +2,7 @@ class Image {
   int x, y;
   int targetX, targetY;
   float easing = 0.1;
+  int currentScale = 100;
 
   // image effect transition variables
   private static final int BRIGHTNESS_VALUE = 0;
@@ -333,6 +334,10 @@ class Image {
     picture.resize(w, h);
   }
 
+  void setScale(int s) {
+    currentScale = s;
+  }
+
   void applyEffects() {
     // iterate through all possible effects 
     for (int i = 0; i < NUM_TRANSITIONS; i++) {
@@ -379,7 +384,7 @@ class Image {
 
     applyEffects();
     
-    image(picture, x, y);
+    image(picture, x, y, picture.width*(currentScale/100), picture.height*(currentScale/100));
   }
 
 };

--- a/video.pde
+++ b/video.pde
@@ -3,6 +3,7 @@ class Video {
   int targetX, targetY;
   float easing = 0.1;
   float speed;
+  int currentScale = 100;
 
   Movie video;
 
@@ -38,6 +39,10 @@ class Video {
     return video;
   }
 
+  void setScale(int s) {
+    currentScale = s;
+  }
+
   void draw() {
     int dx = targetX - x;
     if(abs(dx) > 1) {
@@ -48,6 +53,7 @@ class Video {
     if(abs(dy) > 1) {
       y += dy * easing;
     }
-    image(video, x, y);
+
+    image(video, x, y, video.width*(currentScale/100), video.height*(currentScale/100));
   }
 };


### PR DESCRIPTION
accept `"scale": 200` key-val pairs with scale int value being scale %. i.e. 200 scales image by 200% (double the size)

scaling is only applied when drawing, actual width and height of image is preserved
