### PR TITLE
Single object list

### DIFF
--- a/channel.pde
+++ b/channel.pde
@@ -3,15 +3,6 @@ class Channel implements Runnable {
   Hashtable<Integer, Video> videos;
   Hashtable<Integer, AnimatedGif> gifs;
 
-  Image backImage;
-  int backImageId;
-
-  AnimatedGif backGif;
-  int backGifId;
-
-  Video backVideo;
-  int backVideoId;
-
   String textStr;
   int textPosX;
   int textPosY;
@@ -26,7 +17,6 @@ class Channel implements Runnable {
     images = new Hashtable<Integer, Image>();
     videos = new Hashtable<Integer, Video>();
     gifs = new Hashtable<Integer, AnimatedGif>();
-    backGifId = backImageId = backVideoId = -1;
 
     this.queue = queue;
   }
@@ -79,16 +69,6 @@ class Channel implements Runnable {
     }
   }
 
-  void drawBackground(PApplet app) {
-    if (backImage != null) {
-      app.image(backImage.getPImage(), 0, 0, WIDTH, HEIGHT);
-    } else if (backGif != null) {
-      app.image(backGif.getGif(), 0, 0, WIDTH, HEIGHT);
-    } else if (backVideo != null) {
-      app.image(backVideo.getMovie(), 0, 0, WIDTH, HEIGHT);
-    }
-  }
-
   void drawAll(PApplet app) {
     // Draw all videos
     Enumeration<Video> v = videos.elements();
@@ -122,9 +102,7 @@ class Channel implements Runnable {
     }
 
     if (instr.getString("method").equals("create")) {
-      if (instr.hasKey("background")) {
-        setBackground(instr);
-      } else if (instr.hasKey("image")) {
+      if (instr.hasKey("image")) {
         createImage(instr);
       } else if (instr.hasKey("video")) {
         createVideo(instr);
@@ -133,11 +111,11 @@ class Channel implements Runnable {
       }
     }
     else if (instr.getString("method").equals("update")) {
-      if (images.containsKey(id) || backImageId == id) {
+      if (images.containsKey(id)) {
         updateImage(instr, id);
-      } else if (gifs.containsKey(id) || backGifId == id) {
+      } else if (gifs.containsKey(id)) {
         updateGif(instr, id);
-      } else if (videos.containsKey(id) || backVideoId == id) {
+      } else if (videos.containsKey(id)) {
         updateVideo(instr, id);
       } else {
         println("[error] Invalid ID: "+id+" for update");
@@ -152,45 +130,6 @@ class Channel implements Runnable {
         deleteVideo(instr, id);
       } else {
         println("[error] Invalid ID: "+id+" for delete");
-      }
-    }
-  }
-
-  void setBackground(JSONObject instr) {
-    backGif = null;
-    backImage = null;
-    backVideo = null;
-    backGifId = backImageId = backVideoId = -1;
-    
-    boolean hidden = false;
-    if (instr.hasKey("hidden")) {
-      hidden = instr.getBoolean("hidden");
-    }
-
-    if (instr.hasKey("image")) {
-      String filename = instr.getString("image");
-      File f = new File(dataPath(filename));
-
-      if (f.exists()) {
-        if (filename.endsWith(".gif")) {
-          AnimatedGif gif = new AnimatedGif(filename, 0, 0, hidden);
-          backGif = gif; backGifId = instr.getInt("id");
-        } else {
-          Image img = new Image(filename, 0, 0, hidden);
-          backImage = img; backImageId = instr.getInt("id");
-        }
-      } else {
-        println("[error] File "+filename+" does not exist");
-      }
-    } else if (instr.hasKey("video")) {
-      String filename = instr.getString("video");
-
-      File f = new File(dataPath(filename));
-      if (f.exists()) {
-        Video vid = new Video(filename, 0, 0, hidden);
-        backVideo = vid; backVideoId = instr.getInt("id");
-      } else {
-        println("[error] File "+filename+" does not exist");
       }
     }
   }
@@ -249,12 +188,7 @@ class Channel implements Runnable {
   }
 
   void updateImage(JSONObject instr, Integer id) {
-    Image img;
-    if (backImageId ==  id) {
-      img = backImage;
-    } else {
-      img = (Image) images.get(id);
-    }
+    Image img = images.get(id);
 
     if (instr.hasKey("hidden")) {
       img.setHidden(instr.getBoolean("hidden"));
@@ -367,12 +301,7 @@ class Channel implements Runnable {
   }
 
   void updateGif(JSONObject instr, Integer id) {
-    AnimatedGif gif;
-    if (backGifId == id) {
-      gif = backGif;
-    } else {
-      gif = gifs.get(id);
-    }
+    AnimatedGif gif = gifs.get(id);
 
     if (instr.hasKey("hidden")) {
       gif.setHidden(instr.getBoolean("hidden"));
@@ -477,12 +406,7 @@ class Channel implements Runnable {
   }
 
   void updateVideo(JSONObject instr, Integer id) {
-    Video vid;
-    if (backVideoId ==  id) {
-      vid = backVideo;
-    } else {
-      vid = (Video) videos.get(id);
-    }
+    Video vid = (Video) videos.get(id);
 
     if (instr.hasKey("hidden")) {
       vid.setHidden(instr.getBoolean("hidden"));

--- a/channel.pde
+++ b/channel.pde
@@ -1,7 +1,7 @@
 class Channel implements Runnable {
-  Hashtable<Integer, Image> images;
-  Hashtable<Integer, Video> videos;
-  Hashtable<Integer, AnimatedGif> gifs;
+  HashMap<Integer, Image> images;
+  HashMap<Integer, Video> videos;
+  HashMap<Integer, AnimatedGif> gifs;
 
   String textStr;
   int textPosX;
@@ -14,9 +14,9 @@ class Channel implements Runnable {
   ConcurrentLinkedQueue<JSONObject> queue;
   
   Channel(ConcurrentLinkedQueue<JSONObject> queue) {
-    images = new Hashtable<Integer, Image>();
-    videos = new Hashtable<Integer, Video>();
-    gifs = new Hashtable<Integer, AnimatedGif>();
+    images = new HashMap<Integer, Image>();
+    videos = new HashMap<Integer, Video>();
+    gifs = new HashMap<Integer, AnimatedGif>();
 
     this.queue = queue;
   }
@@ -35,17 +35,14 @@ class Channel implements Runnable {
 
       if (instr != null) {
         if (instr.hasKey("master")) {
-          Enumeration<Integer> v = videos.keys();
-          while (v.hasMoreElements()) {
-            applyInstrToId(instr, v.nextElement());
+          for (Integer key : videos.keySet()) {
+            applyInstrToId(instr, key);
           }
-          Enumeration<Integer> g = gifs.keys();
-          while (g.hasMoreElements()) {
-            applyInstrToId(instr, g.nextElement());
+          for (Integer key : images.keySet()) {
+            applyInstrToId(instr, key);
           }
-          Enumeration<Integer> i = images.keys();
-          while (i.hasMoreElements()) {
-            applyInstrToId(instr, i.nextElement());
+          for (Integer key : gifs.keySet()) {
+            applyInstrToId(instr, key);
           }
         } 
         else if (!instr.hasKey("id")) {
@@ -71,21 +68,18 @@ class Channel implements Runnable {
 
   void drawAll(PApplet app) {
     // Draw all videos
-    Enumeration<Video> v = videos.elements();
-    while (v.hasMoreElements()) {
-      v.nextElement().draw(app);
+    for (Video value : videos.values()) {
+      value.draw(app);
     }
 
     // Draw all images
-    Enumeration<Image> i = images.elements();
-    while (i.hasMoreElements()) {
-      i.nextElement().draw(app);
+    for (Image value : images.values()) {
+      value.draw(app);
     }
 
     // Draw all gifs
-    Enumeration<AnimatedGif> g = gifs.elements();
-    while (g.hasMoreElements()) {
-      g.nextElement().draw(app);
+    for (AnimatedGif value : gifs.values()) {
+      value.draw(app);
     }
 
     // Draw all text

--- a/channel.pde
+++ b/channel.pde
@@ -1,7 +1,7 @@
 class Channel implements Runnable {
-  HashMap<Integer, Image> images;
-  HashMap<Integer, Video> videos;
-  HashMap<Integer, AnimatedGif> gifs;
+  LinkedHashMap<Integer, Image> images;
+  LinkedHashMap<Integer, Video> videos;
+  LinkedHashMap<Integer, AnimatedGif> gifs;
 
   String textStr;
   int textPosX;
@@ -14,9 +14,9 @@ class Channel implements Runnable {
   ConcurrentLinkedQueue<JSONObject> queue;
   
   Channel(ConcurrentLinkedQueue<JSONObject> queue) {
-    images = new HashMap<Integer, Image>();
-    videos = new HashMap<Integer, Video>();
-    gifs = new HashMap<Integer, AnimatedGif>();
+    images = new LinkedHashMap<Integer, Image>();
+    videos = new LinkedHashMap<Integer, Video>();
+    gifs = new LinkedHashMap<Integer, AnimatedGif>();
 
     this.queue = queue;
   }

--- a/channel.pde
+++ b/channel.pde
@@ -1,6 +1,6 @@
 class Channel implements Runnable {
-  Hashtable<Integer, MediaObject> images;
-  Hashtable<Integer, MediaObject> videos;
+  Hashtable<Integer, Image> images;
+  Hashtable<Integer, Video> videos;
   Hashtable<Integer, AnimatedGif> gifs;
 
   Image backImage;
@@ -23,8 +23,8 @@ class Channel implements Runnable {
   ConcurrentLinkedQueue<JSONObject> queue;
   
   Channel(ConcurrentLinkedQueue<JSONObject> queue) {
-    images = new Hashtable<Integer, MediaObject>();
-    videos = new Hashtable<Integer, MediaObject>();
+    images = new Hashtable<Integer, Image>();
+    videos = new Hashtable<Integer, Video>();
     gifs = new Hashtable<Integer, AnimatedGif>();
     backGifId = backImageId = backVideoId = -1;
 
@@ -91,13 +91,13 @@ class Channel implements Runnable {
 
   void drawAll(PApplet app) {
     // Draw all videos
-    Enumeration<MediaObject> v = videos.elements();
+    Enumeration<Video> v = videos.elements();
     while (v.hasMoreElements()) {
       v.nextElement().draw(app);
     }
 
     // Draw all images
-    Enumeration<MediaObject> i = images.elements();
+    Enumeration<Image> i = images.elements();
     while (i.hasMoreElements()) {
       i.nextElement().draw(app);
     }

--- a/channel.pde
+++ b/channel.pde
@@ -1,6 +1,6 @@
 class Channel implements Runnable {
-  Hashtable<Integer, Image> images;
-  Hashtable<Integer, Video> videos;
+  Hashtable<Integer, MediaObject> images;
+  Hashtable<Integer, MediaObject> videos;
   Hashtable<Integer, AnimatedGif> gifs;
 
   Image backImage;
@@ -23,8 +23,8 @@ class Channel implements Runnable {
   ConcurrentLinkedQueue<JSONObject> queue;
   
   Channel(ConcurrentLinkedQueue<JSONObject> queue) {
-    images = new Hashtable<Integer, Image>();
-    videos = new Hashtable<Integer, Video>();
+    images = new Hashtable<Integer, MediaObject>();
+    videos = new Hashtable<Integer, MediaObject>();
     gifs = new Hashtable<Integer, AnimatedGif>();
     backGifId = backImageId = backVideoId = -1;
 
@@ -48,6 +48,10 @@ class Channel implements Runnable {
           Enumeration<Integer> v = videos.keys();
           while (v.hasMoreElements()) {
             applyInstrToId(instr, v.nextElement());
+          }
+          Enumeration<Integer> g = gifs.keys();
+          while (g.hasMoreElements()) {
+            applyInstrToId(instr, g.nextElement());
           }
           Enumeration<Integer> i = images.keys();
           while (i.hasMoreElements()) {
@@ -87,13 +91,13 @@ class Channel implements Runnable {
 
   void drawAll(PApplet app) {
     // Draw all videos
-    Enumeration<Video> v = videos.elements();
+    Enumeration<MediaObject> v = videos.elements();
     while (v.hasMoreElements()) {
       v.nextElement().draw(app);
     }
 
     // Draw all images
-    Enumeration<Image> i = images.elements();
+    Enumeration<MediaObject> i = images.elements();
     while (i.hasMoreElements()) {
       i.nextElement().draw(app);
     }
@@ -249,7 +253,7 @@ class Channel implements Runnable {
     if (backImageId ==  id) {
       img = backImage;
     } else {
-      img = images.get(id);
+      img = (Image) images.get(id);
     }
 
     if (instr.hasKey("hidden")) {
@@ -477,7 +481,7 @@ class Channel implements Runnable {
     if (backVideoId ==  id) {
       vid = backVideo;
     } else {
-      vid = videos.get(id);
+      vid = (Video) videos.get(id);
     }
 
     if (instr.hasKey("hidden")) {

--- a/channel.pde
+++ b/channel.pde
@@ -3,6 +3,8 @@ class Channel implements Runnable {
   LinkedHashMap<Integer, Video> videos;
   LinkedHashMap<Integer, AnimatedGif> gifs;
 
+  LinkedHashMap<Integer, MediaType> mapping;
+
   String textStr;
   int textPosX;
   int textPosY;
@@ -17,6 +19,7 @@ class Channel implements Runnable {
     images = new LinkedHashMap<Integer, Image>();
     videos = new LinkedHashMap<Integer, Video>();
     gifs = new LinkedHashMap<Integer, AnimatedGif>();
+    mapping = new LinkedHashMap<Integer, MediaType>();
 
     this.queue = queue;
   }
@@ -67,19 +70,15 @@ class Channel implements Runnable {
   }
 
   void drawAll(PApplet app) {
-    // Draw all videos
-    for (Video value : videos.values()) {
-      value.draw(app);
-    }
+    // Draw all objects
+    for (Integer id : mapping.keySet()) {
+      MediaType type = mapping.get(id);
 
-    // Draw all images
-    for (Image value : images.values()) {
-      value.draw(app);
-    }
-
-    // Draw all gifs
-    for (AnimatedGif value : gifs.values()) {
-      value.draw(app);
+      switch (type) {
+        case IMAGE: Image img = images.get(id); img.draw(app); break;
+        case ANIMATEDGIF: AnimatedGif gif = gifs.get(id); gif.draw(app); break;
+        case VIDEO: Video vid = videos.get(id); vid.draw(app); break;
+      }
     }
 
     // Draw all text
@@ -142,9 +141,11 @@ class Channel implements Runnable {
       if (filename.endsWith(".gif")) {
         AnimatedGif gif = new AnimatedGif(filename, posX, posY, h);
         gifs.put(instr.getInt("id"), gif);
+        mapping.put(instr.getInt("id"), MediaType.ANIMATEDGIF);
       } else {
         Image img = new Image(filename, posX, posY, h);
         images.put(instr.getInt("id"), img);
+        mapping.put(instr.getInt("id"), MediaType.IMAGE);
       }
     } else {
       println("[error] File "+filename+" does not exist");
@@ -164,6 +165,7 @@ class Channel implements Runnable {
     if (f.exists()) {
       Video vid = new Video(filename, posX, posY, h);
       videos.put(instr.getInt("id"), vid);
+      mapping.put(instr.getInt("id"), MediaType.VIDEO);
     } else {
       println("[error] File "+filename+" does not exist");
     }
@@ -171,14 +173,17 @@ class Channel implements Runnable {
 
   void deleteImage(JSONObject instr, Integer id) {
     images.remove(id);
+    mapping.remove(id);
   }
 
   void deleteGif(JSONObject instr, Integer id) {
     gifs.remove(id);
+    mapping.remove(id);
   }
   
   void deleteVideo(JSONObject instr, Integer id) {
     videos.remove(id);
+    mapping.remove(id);
   }
 
   void updateImage(JSONObject instr, Integer id) {

--- a/image.pde
+++ b/image.pde
@@ -1,11 +1,5 @@
-class Image {
-  int x, y;
-  int targetX, targetY;
-  float easing = 0.1;
-  float currentScale = 1.0;
-  float width, height;
+class Image extends MediaObject {
   int degsToRotate;
-  boolean hidden = false;
 
   // image effect transition variables
   private static final int BRIGHTNESS_VALUE = 0;
@@ -57,15 +51,6 @@ class Image {
     updateFlag = new boolean[NUM_TRANSITIONS];
     degsToRotate = 0;
 
-  }
-
-  void setEasing(float e) {
-    easing = e;
-  }
-
-  void updateTargetPostion(int posX, int posY) {
-    targetX = posX;
-    targetY = posY;
   }
 
   void startBrightness(int totalMagnitude, int totalUpdateTime, int numUpdates) {
@@ -464,15 +449,6 @@ class Image {
     picture.filter(THRESHOLD, constrainedValue);
   }
 
-  void updateSize(float w, float h) {
-    width = w;
-    height = h;
-  }
-
-  void setScale(int s) {
-    currentScale = (float) s/100.0;
-  }
-
   void setRotation(int degs) {
     degsToRotate = degs;
   }
@@ -521,14 +497,11 @@ class Image {
     return picture;
   }
 
-  void setHidden(boolean h) {
-    hidden = h;
-  }
-
   void reset() {
     picture.copy(originalPicture, 0, 0, originalPicture.width, originalPicture.height, 0, 0, originalPicture.width, originalPicture.height);
   }
 
+  @Override
   void draw(PApplet app) {
     int dx = targetX - x;
     if(abs(dx) > 1) {

--- a/instruction_delegator.pde
+++ b/instruction_delegator.pde
@@ -13,9 +13,8 @@ class InstructionDelegator implements Runnable {
 
         if (instr != null) {
           if (instr.hasKey("master")) {
-            Enumeration<ConcurrentLinkedQueue<JSONObject>> channelQueue = queues.elements();
-            while (channelQueue.hasMoreElements()) {
-              channelQueue.nextElement().add(instr);
+            for (ConcurrentLinkedQueue<JSONObject> channelQueue : queues.values()) {
+              channelQueue.add(instr);
             }
 
             if (RECORD) {

--- a/media_object.pde
+++ b/media_object.pde
@@ -1,0 +1,35 @@
+class MediaObject {
+  int x, y;
+  int targetX, targetY;
+  float easing = 0.1;
+  float speed;
+  float currentScale = 1.0;
+  float width, height;
+  boolean hidden;
+
+  void setEasing(float e) {
+    easing = e;
+  }
+
+  void updateTargetPostion(int posX, int posY) {
+    targetX = posX;
+    targetY = posY;
+  }
+
+  void updateSize(float w, float h) {
+    width = w;
+    height = h;
+  }
+
+  void setScale(int s) {
+    currentScale = (float) s/100.0;
+  }
+
+
+  void setHidden(boolean h) {
+    hidden = h;
+  }
+  
+  void draw(PApplet app) {
+  }
+};

--- a/media_type.java
+++ b/media_type.java
@@ -1,0 +1,5 @@
+enum MediaType {
+  IMAGE, 
+  ANIMATEDGIF, 
+  VIDEO
+};

--- a/video.pde
+++ b/video.pde
@@ -1,12 +1,4 @@
-class Video {
-  int x, y;
-  int targetX, targetY;
-  float easing = 0.1;
-  float speed;
-  float currentScale = 1.0;
-  float width, height;
-  boolean hidden;
-
+class Video extends MediaObject {
   Movie video;
 
   Video(String filename, int posX, int posY, boolean h) {
@@ -17,10 +9,6 @@ class Video {
     width = video.width;
     height = video.height;
     hidden = h;
-  }
-
-  void setEasing(float e) {
-    easing = e;
   }
 
   void setPlaybackSpeed(float s) {
@@ -35,28 +23,11 @@ class Video {
     video.speed(speed);
   }
 
-  void updateTargetPostion(int posX, int posY) {
-    targetX = posX;
-    targetY = posY;
-  }
-
   Movie getMovie() {
     return video;
   }
-
-  void setScale(int s) {
-    currentScale = (float) s/100.0;
-  }
-
-  void updateSize(float w, float h) {
-    width = w;
-    height = h;
-  }
-
-  void setHidden(boolean h) {
-    hidden = h;
-  }
-
+  
+  @Override
   void draw(PApplet app) {
     int dx = targetX - x;
     if(abs(dx) > 1) {

--- a/viper.pde
+++ b/viper.pde
@@ -114,7 +114,7 @@ void createStageWindow() {
     sketchHeight = HEIGHT; sketchWidth = WIDTH;
   }
 
-  p_window = new GWindow(this, "Performance Window", 0, 0, sketchWidth, sketchHeight, true, OPENGL);
+  p_window = new GWindow(this, "Performance Window", 0, 0, sketchWidth, sketchHeight, false, OPENGL);
   p_window.setActionOnClose(G4P.CLOSE_WINDOW);
   p_window.addDrawHandler(this, "p_window_draw1");
 }

--- a/viper.pde
+++ b/viper.pde
@@ -118,14 +118,8 @@ void createStageWindow() {
 synchronized public void p_window_draw1(GWinApplet appc, GWinData data) {
   appc.background(230);
 
-  // Draw all channels background
-  Enumeration<Channel> channel = channels.elements();
-  while (channel.hasMoreElements ()) {
-    channel.nextElement().drawBackground(appc);
-  }
-
   // Draw all channels
-  channel = channels.elements();
+  Enumeration<Channel> channel = channels.elements();
   while (channel.hasMoreElements ()) {
     channel.nextElement().drawAll(appc);
   }

--- a/viper.pde
+++ b/viper.pde
@@ -8,7 +8,6 @@ import gifAnimation.*;
 import g4p_controls.*;
 import processing.opengl.*;
 
-
 static boolean TESTMODE = false;
 static boolean RECORD = false;
 static boolean VERBOSE_LOG = false;

--- a/viper.pde
+++ b/viper.pde
@@ -46,6 +46,7 @@ void setup() {
 
 void draw() {}
 
+// Called by Run button in GUI
 void runViper() {
   createStageWindow();
 
@@ -56,22 +57,16 @@ void runViper() {
     recorders.put("master", recorder);
   }
 
+  mainQueue = new ConcurrentLinkedQueue<JSONObject>();
+
   if (TESTMODE) {
-    mainQueue = new ConcurrentLinkedQueue<JSONObject>();
     addTestChannels();
-
-    Thread delegateInstructions = new Thread(new InstructionDelegator(mainQueue));
-    delegateInstructions.start();
-
   } else {
-    
     oscServer.runServer();
-
-    mainQueue = new ConcurrentLinkedQueue<JSONObject>();
-    
-    Thread delegateInstructions = new Thread(new InstructionDelegator(mainQueue));
-    delegateInstructions.start();
   }
+
+  Thread delegateInstructions = new Thread(new InstructionDelegator(mainQueue));
+  delegateInstructions.start();
 }
 
 ConcurrentLinkedQueue<JSONObject> addChannel(String deviceID) {
@@ -99,6 +94,7 @@ ConcurrentLinkedQueue<JSONObject> addChannel(String deviceID) {
 void removeChannel(String deviceID) {
   queues.remove(deviceID);
   channels.remove(deviceID);
+  recorders.remove(deviceID);
 }
 
 // Called every time a new frame is available to read

--- a/viper.pde
+++ b/viper.pde
@@ -21,9 +21,9 @@ static boolean FULLSCREEN = false;
 PApplet main_app;
 GWindow p_window;
 
-HashMap<String, Channel> channels;
-HashMap<String, ConcurrentLinkedQueue<JSONObject>> queues;
-HashMap<String, PrintWriter> recorders;
+LinkedHashMap<String, Channel> channels;
+LinkedHashMap<String, ConcurrentLinkedQueue<JSONObject>> queues;
+LinkedHashMap<String, PrintWriter> recorders;
 ConcurrentLinkedQueue<JSONObject> mainQueue;
 
 OSCServer oscServer = new OSCServer();
@@ -39,8 +39,8 @@ void setup() {
   String myWAN = NetInfo.wan();
   ip.setText(myWAN);
 
-  channels = new HashMap<String, Channel>();
-  queues = new HashMap<String, ConcurrentLinkedQueue<JSONObject>>();
+  channels = new LinkedHashMap<String, Channel>();
+  queues = new LinkedHashMap<String, ConcurrentLinkedQueue<JSONObject>>();
 }
 
 void draw() {}
@@ -50,7 +50,7 @@ void runViper() {
   createStageWindow();
 
   if (RECORD) {
-    recorders = new HashMap<String, PrintWriter>();
+    recorders = new LinkedHashMap<String, PrintWriter>();
     
     PrintWriter recorder = createWriter("logs/master/messages.json");
     recorders.put("master", recorder);

--- a/viper.pde
+++ b/viper.pde
@@ -1,5 +1,4 @@
 import java.util.Map;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.io.*;
 import java.util.*;
@@ -22,9 +21,9 @@ static boolean FULLSCREEN = false;
 PApplet main_app;
 GWindow p_window;
 
-Hashtable<String, Channel> channels;
-Hashtable<String, ConcurrentLinkedQueue<JSONObject>> queues;
-Hashtable<String, PrintWriter> recorders;
+HashMap<String, Channel> channels;
+HashMap<String, ConcurrentLinkedQueue<JSONObject>> queues;
+HashMap<String, PrintWriter> recorders;
 ConcurrentLinkedQueue<JSONObject> mainQueue;
 
 OSCServer oscServer = new OSCServer();
@@ -40,8 +39,8 @@ void setup() {
   String myWAN = NetInfo.wan();
   ip.setText(myWAN);
 
-  channels = new Hashtable<String, Channel>();
-  queues = new Hashtable<String, ConcurrentLinkedQueue<JSONObject>>();
+  channels = new HashMap<String, Channel>();
+  queues = new HashMap<String, ConcurrentLinkedQueue<JSONObject>>();
 }
 
 void draw() {}
@@ -51,7 +50,7 @@ void runViper() {
   createStageWindow();
 
   if (RECORD) {
-    recorders = new Hashtable<String, PrintWriter>();
+    recorders = new HashMap<String, PrintWriter>();
     
     PrintWriter recorder = createWriter("logs/master/messages.json");
     recorders.put("master", recorder);
@@ -119,9 +118,8 @@ synchronized public void p_window_draw1(GWinApplet appc, GWinData data) {
   appc.background(230);
 
   // Draw all channels
-  Enumeration<Channel> channel = channels.elements();
-  while (channel.hasMoreElements ()) {
-    channel.nextElement().drawAll(appc);
+  for (Channel channel : channels.values()) {
+    channel.drawAll(appc);
   }
 
 }


### PR DESCRIPTION
Includes a bunch of changes, the most important being that image, video and gif ids are stored in a `LinkedHashMap` mapping structure that allows drawing of objects in insertion order (no matter type). 

Also removed the background images/gifs/videos as it was confusing. (Can still set a background - but this has to be done by creating an object as per usual and have to make sure that the size specified is right)